### PR TITLE
Update module.json for v10

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,16 +2,22 @@
 	"name": "Waterdeep-City-of-Splendors",
 	"title": "Waterdeep - City of Splendors",
 	"description": "A full Waterdeep map with all locations as presented by https://www.aidedd.org/",
-	"version": "1.0.0",
-	"minimumCoreVersion": "0.8.9",
-	"compatibleCoreVersion": "9",
-	"author": "Gage Eakins",
+	"version": "1.4.1",
+	"compatibility": {
+		"minimum": "0.8.9",
+		"verified": "10.288"
+	},
+	"authors": [
+		{
+			"name": "Gage Eakins"
+		}
+	],
 	"packs": [
 		{
 			"name": "maps",
 			"label": "Waterdeep - City of Splendors",
 			"path": "/packs/maps.db",
-			"entity": "Scene",
+			"type": "Scene",
 			"system": "dnd5e",
 			"module": "Waterdeep-City-of-Splendors"
 		},
@@ -19,7 +25,7 @@
 			"name": "journals",
 			"label": "Waterdeep - City of Splendors",
 			"path": "/packs/journals.db",
-			"entity": "JournalEntry",
+			"type": "JournalEntry",
 			"system": "dnd5e",
 			"module": "Waterdeep-City-of-Splendors"
 		}
@@ -27,17 +33,21 @@
 	"esmodules": [
 		"./scripts/init.js"
 	],
-	"dependencies": [
-		{
-			"name": "scene-packer",
-			"type": "module"
-		},
-		{
-			"name": "compendium-folders",
-			"type": "module"
-		}
-	],
+	"relationships": {
+		"requires": [
+			{
+				"id": "scene-packer",
+				"type": "module",
+				"manifest": "https://github.com/League-of-Foundry-Developers/scene-packer/releases/latest/download/module.json"
+			},
+			{
+				"id": "compendium-folders",
+				"type": "module",
+				"manifest": "https://raw.githubusercontent.com/earlSt1/vtt-compendium-folders/10x-update/module.json"
+			}
+		]
+	},	
 	"url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
 	"manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
-	"download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/download/v1.1.1/Waterdeep-City-of-Splendors.zip"
+	"download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/download/v1.4/Waterdeep-City-of-Splendors.zip"
 }


### PR DESCRIPTION
**The module as it currently is works for v10 without issue.**

This pull request resolves deprecation warnings FoundryVTT flags with this package.

Changes:

* update [compatibility](https://foundryvtt.com/api/interfaces/foundry.packages.PackageManifestData.html#compatibility)
* change `author` to [`authors`](https://foundryvtt.com/api/interfaces/foundry.packages.PackageManifestData.html#authors)
* change `entity` to [`type`](https://foundryvtt.com/api/interfaces/foundry.packages.PackageCompendiumData.html#type) for compendium packs
* use [`relationships`](https://foundryvtt.com/api/interfaces/foundry.packages.PackageManifestData.html#relationships) to describe `PackageRelationships`
* change [`download`](https://foundryvtt.com/api/interfaces/foundry.packages.PackageManifestData.html#download) to point to v1.4 of the Waterdeep pack (though this will need to be updated after this change)