### PR TITLE
Fixes for Empty Journals and Missing Map

### DIFF
--- a/module.json
+++ b/module.json
@@ -10,8 +10,8 @@
   "description": "A full Waterdeep map with all locations as presented by https://www.aidedd.org/",
   "authors": [
     {
-      "name": "Armand Soulliard",
-      "url": "https://github.com/asoulliard",
+      "name": "Gage Eakins",
+      "url": "https://github.com/webmaster94",
       "flags": {}
     }
   ],
@@ -31,7 +31,7 @@
   "esmodules": [
   "scripts/waterdeep.js"
 ],
-  "url": "https://github.com/asoulliard/Waterdeep-City-of-Splendors",
-  "manifest": "https://github.com/asoulliard/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
-  "download": "https://github.com/asoulliard/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"
+  "url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
+  "manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
+  "download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"
 }

--- a/module.json
+++ b/module.json
@@ -1,5 +1,5 @@
 {
-  "id": "waterdeep-city-of-splendors",
+  "id": "Waterdeep-City-of-Splendors",
   "title": "Waterdeep - City of Splendors",
   "version": "4.0.1",
   "compatibility": {

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "waterdeep-city-of-splendors",
   "title": "Waterdeep - City of Splendors",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "compatibility": {
     "minimum": "11",
     "verified": "12",
@@ -10,8 +10,8 @@
   "description": "A full Waterdeep map with all locations as presented by https://www.aidedd.org/",
   "authors": [
     {
-      "name": "Gage Eakins",
-      "url": "https://github.com/webmaster94",
+      "name": "Armand Soulliard",
+      "url": "https://github.com/asoulliard",
       "flags": {}
     }
   ],
@@ -31,7 +31,7 @@
   "esmodules": [
   "scripts/waterdeep.js"
 ],
-  "url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
-  "manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
-  "download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"
+  "url": "https://github.com/asoulliard/Waterdeep-City-of-Splendors",
+  "manifest": "https://github.com/asoulliard/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
+  "download": "https://github.com/asoulliard/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"
 }

--- a/module.json
+++ b/module.json
@@ -28,6 +28,9 @@
       "flags": {}
     }
   ],
+  "esmodules": [
+  "scripts/waterdeep.js"
+],
   "url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
   "manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
   "download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"

--- a/module.json
+++ b/module.json
@@ -10,8 +10,8 @@
   "description": "A full Waterdeep map with all locations as presented by https://www.aidedd.org/",
   "authors": [
     {
-      "name": "Gage Eakins",
-      "url": "https://github.com/webmaster94",
+      "name": "Armand Soulliard",
+      "url": "https://github.com/asoulliard",
       "flags": {}
     }
   ],
@@ -31,7 +31,7 @@
   "esmodules": [
   "scripts/waterdeep.js"
 ],
-  "url": "https://github.com/webmaster94/Waterdeep-City-of-Splendors",
-  "manifest": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
-  "download": "https://github.com/webmaster94/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"
+  "url": "https://github.com/asoulliard/Waterdeep-City-of-Splendors",
+  "manifest": "https://github.com/asoulliard/Waterdeep-City-of-Splendors/releases/latest/download/module.json",
+  "download": "https://github.com/asoulliard/Waterdeep-City-of-Splendors/releases/latest/download/module.zip"
 }


### PR DESCRIPTION
I changed author and urls so I could differentiate the two when I was installing on my machine, so I don't expect you to merge this pull request, but I submitted it to outline the two specific changes I made.

#6  - Added waterdeep.js as an esmodule to module.json to make sure it runs and populates journals.
#7 - Changed module.json id field to uppercase to properly reference map image.

KNOWN ISSUE: While the casing issue for the scene was resolved, it introduces a problem where the adventure compendium's thumbnail image doesn't show up. _That_ filepath is lowercase. I can't think of a way to resolve both without the adventure being rebuilt, so I prioritized the main map image.